### PR TITLE
ci: removed python3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       max-parallel: 6
       matrix:
         os: [ 'ubuntu-latest', 'macos-latest' ,'windows-latest' ]
-        python: [ 3.6, 3.7, 3.8, 3.9 ]
+        python: [ 3.7, 3.8, 3.9 ]
         # windows and mac are slow to run python 3.9 so we skip these jobs
         # windows is also really slow on python 3.6 and sometimes produce weird errors so we skip it
         exclude:
@@ -40,10 +40,3 @@ jobs:
         run: nox -s tests-${{ matrix.python }}
         env:
           CODECOV_TOKEN: ${{ secrets.codecov_token }}
-      - name: Build and deploy
-        run: nox -s deploy
-        if: >
-          github.event_name == 'push' && contains(github.ref, 'refs/tags/') &&
-          matrix.os == 'ubuntu-latest' && matrix.python == '3.9'
-        env:
-          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.pypi_token }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,24 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  publish:
+    timeout-minutes: 10
+    runs-on: 'ubuntu-latest'
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - name: Install python dependencies
+        run: python -m pip install -U pip nox
+      - name: Build and deploy
+        run: nox -s deploy
+        env:
+          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.pypi_token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,17 @@ The changelog format is based on a subset of [Keep a changelog](https://keepacha
 
 ## [Unreleased]
 
-## Version 0.1.2 - 2021-05-18
+## [0.2.0] - 2022-06-02
+
+### Security
+
+- Updated httpx package to version 0.23.0 (#10)
+
+### Removed
+
+- Dropped support for python3.6 (#10)
+
+## [0.1.2] - 2021-05-18
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ poetry add pyscalpel[trio] # to install the trio backend
 poetry add pyscalpel[full] # to install all the backends
 ```
 
-pyscalpel works starting from **python 3.6**, it relies on robust packages:
+pyscalpel works starting from **python 3.7**, it relies on robust packages:
 - [configuror](https://configuror.readthedocs.io/en/latest/): A configuration toolkit. 
 - [httpx](https://www.python-httpx.org/): A modern http client.
 - [selenium](https://pypi.org/project/selenium/): A library for controlling a browser.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-To install pyscalpel, you will need to have python and pip installed. For python the minimal version supported is **3.6**.
+To install pyscalpel, you will need to have python and pip installed. For python the minimal version supported is **3.7**.
 After you can just enter the following command:
 
 ```bash

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,7 +8,7 @@ anyio
 selenium==3.141.0
 idna>=2.0.0,<3.0.0
 rfc3986==1.4.0
-httpx==0.17.1
+httpx==0.23.0
 parsel==1.6.0
 msgpack==1.0.3
 fake-useragent==0.1.11

--- a/noxfile.py
+++ b/noxfile.py
@@ -7,7 +7,7 @@ import nox
 
 nox.options.reuse_existing_virtualenvs = True
 
-PYTHON_VERSIONS = ['pypy3', '3.6', '3.7', '3.8', '3.9']
+PYTHON_VERSIONS = ['pypy3', '3.7', '3.8', '3.9']
 CI_ENVIRONMENT = 'GITHUB_ACTIONS' in os.environ
 
 
@@ -15,7 +15,7 @@ CI_ENVIRONMENT = 'GITHUB_ACTIONS' in os.environ
 def lint(session):
     """Performs pep8 and security checks."""
     source_code = 'scalpel'
-    session.install('flake8==3.8.4', 'bandit==1.6.2')
+    session.install('flake8==3.9.2', 'bandit==1.7.4')
     session.run('flake8', source_code)
     session.run('bandit', '-r', source_code)
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -296,47 +296,49 @@ docs = ["sphinx"]
 
 [[package]]
 name = "h11"
-version = "0.13.0"
+version = "0.12.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
-[package.dependencies]
-typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
-
 [[package]]
 name = "httpcore"
-version = "0.12.3"
+version = "0.15.0"
 description = "A minimal low-level HTTP client."
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
-h11 = "<1.0.0"
+anyio = ">=3.0.0,<4.0.0"
+certifi = "*"
+h11 = ">=0.11,<0.13"
 sniffio = ">=1.0.0,<2.0.0"
 
 [package.extras]
 http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (>=1.0.0,<2.0.0)"]
 
 [[package]]
 name = "httpx"
-version = "0.17.1"
+version = "0.23.0"
 description = "The next generation HTTP client."
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
 certifi = "*"
-httpcore = ">=0.12.1,<0.13"
+httpcore = ">=0.15.0,<0.16.0"
 rfc3986 = {version = ">=1.3,<2", extras = ["idna2008"]}
 sniffio = "*"
 
 [package.extras]
-brotli = ["brotlipy (>=0.7.0,<0.8.0)"]
-http2 = ["h2 (>=3.0.0,<4.0.0)"]
+brotli = ["brotlicffi", "brotli"]
+cli = ["click (>=8.0.0,<9.0.0)", "rich (>=10,<13)", "pygments (>=2.0.0,<3.0.0)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (>=1.0.0,<2.0.0)"]
 
 [[package]]
 name = "idna"
@@ -749,14 +751,14 @@ use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
 
 [[package]]
 name = "respx"
-version = "0.16.3"
+version = "0.19.2"
 description = "A utility for mocking out the Python HTTPX and HTTP Core libraries."
 category = "dev"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-httpx = ">=0.15"
+httpx = ">=0.21.0"
 
 [[package]]
 name = "rfc3986"
@@ -967,7 +969,7 @@ trio = ["trio"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "e7f65f379fc3482659c64762b967f4279c013181171df24d75b484ba32927809"
+content-hash = "f341fdaf741abb8694bba162b58df604d4bc0500d45cf0e164918cf6d8025d5a"
 
 [metadata.files]
 anyio = [
@@ -1239,16 +1241,16 @@ greenlet = [
     {file = "greenlet-1.1.2.tar.gz", hash = "sha256:e30f5ea4ae2346e62cedde8794a56858a67b878dd79f7df76a0767e356b1744a"},
 ]
 h11 = [
-    {file = "h11-0.13.0-py3-none-any.whl", hash = "sha256:8ddd78563b633ca55346c8cd41ec0af27d3c79931828beffb46ce70a379e7442"},
-    {file = "h11-0.13.0.tar.gz", hash = "sha256:70813c1135087a248a4d38cc0e1a0181ffab2188141a93eaf567940c3957ff06"},
+    {file = "h11-0.12.0-py3-none-any.whl", hash = "sha256:36a3cb8c0a032f56e2da7084577878a035d3b61d104230d4bd49c0c6b555a9c6"},
+    {file = "h11-0.12.0.tar.gz", hash = "sha256:47222cb6067e4a307d535814917cd98fd0a57b6788ce715755fa2b6c28b56042"},
 ]
 httpcore = [
-    {file = "httpcore-0.12.3-py3-none-any.whl", hash = "sha256:93e822cd16c32016b414b789aeff4e855d0ccbfc51df563ee34d4dbadbb3bcdc"},
-    {file = "httpcore-0.12.3.tar.gz", hash = "sha256:37ae835fb370049b2030c3290e12ed298bf1473c41bb72ca4aa78681eba9b7c9"},
+    {file = "httpcore-0.15.0-py3-none-any.whl", hash = "sha256:1105b8b73c025f23ff7c36468e4432226cbb959176eab66864b8e31c4ee27fa6"},
+    {file = "httpcore-0.15.0.tar.gz", hash = "sha256:18b68ab86a3ccf3e7dc0f43598eaddcf472b602aba29f9aa6ab85fe2ada3980b"},
 ]
 httpx = [
-    {file = "httpx-0.17.1-py3-none-any.whl", hash = "sha256:d379653bd457e8257eb0df99cb94557e4aac441b7ba948e333be969298cac272"},
-    {file = "httpx-0.17.1.tar.gz", hash = "sha256:cc2a55188e4b25272d2bcd46379d300f632045de4377682aa98a8a6069d55967"},
+    {file = "httpx-0.23.0-py3-none-any.whl", hash = "sha256:42974f577483e1e932c3cdc3cd2303e883cbfba17fe228b0f63589764d7b9c4b"},
+    {file = "httpx-0.23.0.tar.gz", hash = "sha256:f28eac771ec9eb4866d3fb4ab65abd42d38c424739e80c08d8d20570de60b0ef"},
 ]
 idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
@@ -1540,8 +1542,8 @@ requests = [
     {file = "requests-2.27.1.tar.gz", hash = "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61"},
 ]
 respx = [
-    {file = "respx-0.16.3-py2.py3-none-any.whl", hash = "sha256:2db35e4af6bf25f58435457da7a0df52b34b8b3c2ea584d8a8cce27a7b00a614"},
-    {file = "respx-0.16.3.tar.gz", hash = "sha256:3f4781a7fc02d6162f63f33c1481b31d83c0b8c54e98a077932a4197182a7312"},
+    {file = "respx-0.19.2-py2.py3-none-any.whl", hash = "sha256:417f986fec599b9cc6531e93e494b7a75d1cb7bccff9dde5b53edc51f7954494"},
+    {file = "respx-0.19.2.tar.gz", hash = "sha256:f3d210bb4de0ccc4c5afabeb87c3c1b03b3765a9c1a73eb042a07bb18ac33705"},
 ]
 rfc3986 = [
     {file = "rfc3986-1.5.0-py2.py3-none-any.whl", hash = "sha256:a86d6e1f5b1dc238b218b012df0aa79409667bb209e58da56d0b94704e712a97"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ rfc3986 = { extras = ["idna"], version = "^1.4.0" }
 msgpack = "^1.0.0"
 gevent = { version = "^20.9.0", optional = true }
 trio = { version = "^0.17.0", optional = true }
-httpx = "^0.17.0"
+httpx = "^0.23.0"
 anyio = "^3.0.0"
 
 [tool.poetry.extras]
@@ -57,7 +57,7 @@ mock = "^4.0.3"
 mkdocs-material = "^7.0.5"
 mkdocs = "^1.1.2"
 mkautodoc = "^0.1.0"
-respx = "^0.16.3"
+respx = "^0.19.0"
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyscalpel"
-version = "0.1.2"
+version = "0.2.0"
 description = "Your easy-to-use, fast and powerful web scraping library"
 authors = ["lewoudar <lewoudar@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
Python 3.6 reached its end of life last year and the project dependencies seemed to moved from it
Also I received an alert from github concerning httpx and the issue is [solved](https://github.com/encode/httpx/blob/master/CHANGELOG.md#0230-23rd-may-2022) in a version dropping python3.6 